### PR TITLE
fix/login-redirect-url

### DIFF
--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -15,7 +15,7 @@ import User from "../models/user.js";
 import OAuth from "./oauth.js";
 import conductorErrors from "../conductor-errors.js";
 import { debugError } from "../debug.js";
-import { assembleUrl, isEmptyString } from "../util/helpers.js";
+import { assembleUrl, isEmptyString, isFullURL } from "../util/helpers.js";
 
 const SALT_ROUNDS = 10;
 const JWT_SECRET = new TextEncoder().encode(process.env.SECRETKEY);
@@ -321,7 +321,13 @@ async function completeLogin(req, res) {
           : `localhost:${process.env.CLIENT_PORT || 3000}`;
       redirectURL = `${oidcCallbackProto}://${domain}`;
     }
-    redirectURL = assembleUrl([redirectURL, state.redirectURI || "home"]);
+    if (state.redirectURI && isFullURL(state.redirectURI)) {
+      redirectURL = state.redirectURI;
+    } else {
+      // redirectURI is only a path or not provided
+      redirectURL = assembleUrl([redirectURL, state.redirectURI ?? "home"]);
+    }
+    
     if (!state.redirectURI && isNewMember) {
       redirectURL = `${redirectURL}?newmember=true`;
     }

--- a/server/util/helpers.js
+++ b/server/util/helpers.js
@@ -248,6 +248,21 @@ export function assembleUrl(parts) {
 }
 
 /**
+ * Validates that a string is a fully-qualified URL.
+ *
+ * @param {string} input - String to validate.
+ * @returns {boolean} True if string is a fully-qualified URL.
+ */
+export function isFullURL(input) {
+  try {
+    const url = new URL(input);
+    return !!url;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * @description Ensures a given string is a safe hex code for use in styling
  * @param {string} hexString - unsafe string to check
  * @returns {string} - sanitized hex code with '#' prepended, empty string if sanitizing failed


### PR DESCRIPTION
Fix broken redirect from CAS when `state.redirectURI` is a full URL and not a path.