### PR TITLE
fix(Threads): change delete comment action highlight color

### DIFF
--- a/client/src/components/Chat/Chat.css
+++ b/client/src/components/Chat/Chat.css
@@ -40,6 +40,10 @@
     word-break: break-all;
 }
 
+.conductor-chat-del:hover {
+    color: red !important;
+}
+
 #conductor-chat-reply-container {
     border-top: 1px solid rgba(34,36,38,.15);
     -webkit-box-shadow: 0 -5px 5px -5px rgb(224, 224, 224);

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -345,7 +345,8 @@ const Chat: FC<Chatinterface>= ({
                     />
                     {((item.author?.uuid === user.uuid) || isProjectAdmin) && (
                       <Comment.Actions>
-                        <Comment.Action
+                        <Comment.Action className="conductor-chat-del"
+                          
                           onClick={() => handleOpenDeleteMessage(item.messageID)}
                         >
                           Delete


### PR DESCRIPTION
Added a css class to the delete comment action component in order to change the hover/highlight color from black to red. 