### PR TITLE
fix(Projects): increase notes width

### DIFF
--- a/client/src/components/projects/ProjectView.jsx
+++ b/client/src/components/projects/ProjectView.jsx
@@ -1863,7 +1863,7 @@ const ProjectView = (props) => {
                           <Grid.Column>
                             <Header as='h3' dividing>Notes</Header>
                             <p
-                              className='project-notes-body prose prose-code:before:hidden prose-code:after:hidden'
+                              className='project-notes-body prose prose-code:before:hidden prose-code:after:hidden max-w-[100%]'
                               dangerouslySetInnerHTML={{
                                 __html: DOMPurify.sanitize(marked(project.notes, { breaks: true }))
                               }}

--- a/client/src/components/projects/ProjectView.jsx
+++ b/client/src/components/projects/ProjectView.jsx
@@ -1863,7 +1863,7 @@ const ProjectView = (props) => {
                           <Grid.Column>
                             <Header as='h3' dividing>Notes</Header>
                             <p
-                              className='project-notes-body prose prose-code:before:hidden prose-code:after:hidden max-w-[100%]'
+                              className='project-notes-body prose prose-code:before:hidden prose-code:after:hidden max-w-full'
                               dangerouslySetInnerHTML={{
                                 __html: DOMPurify.sanitize(marked(project.notes, { breaks: true }))
                               }}


### PR DESCRIPTION
Add inline css to increase width of notes block on project page (to fit the full width of the parent container).