### PR TITLE
ref(API): move book validation schemas

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -46,6 +46,7 @@ import * as ProjectFileValidators from './api/validators/projectfiles.js';
 import * as SearchValidators from './api/validators/search.js';
 import * as AssetTagFrameworkValidators from './api/validators/assettagframeworks.js';
 import * as AuthorsValidators from './api/validators/authors.js';
+import * as BookValidators from './api/validators/book.js';
 
 const router = express.Router();
 
@@ -613,53 +614,53 @@ router.route('/commons/syncwithlibs/automated').put(
 
 /* Commons Books/Catalogs */
 router.route('/commons/catalog').get(
-  middleware.validateZod(booksAPI.getCommonsCatalogSchema),
+  middleware.validateZod(BookValidators.getCommonsCatalogSchema),
   booksAPI.getCommonsCatalog,
 );
 
 router.route('/commons/mastercatalog').get(
-  middleware.validateZod(booksAPI.getMasterCatalogSchema),
+  middleware.validateZod(BookValidators.getMasterCatalogSchema),
   booksAPI.getMasterCatalog,
 );
 
 router.route('/commons/book').post(
   authAPI.verifyRequest,
-  middleware.validateZod(booksAPI.createBookSchema),
+  middleware.validateZod(BookValidators.createBookSchema),
   booksAPI.createBook,
 )
 
 router.route('/commons/book/:bookID').get(
-  middleware.validateZod(booksAPI.getWithBookIDParamSchema),
+  middleware.validateZod(BookValidators.getWithBookIDParamSchema),
   booksAPI.getBookDetail,
 );
 
 router.route('/commons/book/:bookID/summary').get(
-  middleware.validateZod(booksAPI.getWithBookIDParamSchema),
+  middleware.validateZod(BookValidators.getWithBookIDParamSchema),
   booksAPI.getBookSummary,
 );
 
 router.route('/commons/book/:bookID/files/:fileID?').get(
-  middleware.validateZod(booksAPI.getBookFilesSchema),
+  middleware.validateZod(BookValidators.getBookFilesSchema),
   booksAPI.getBookFiles,
 );
 
 router.route('/commons/book/:bookID/files/:fileID/download').get(
-  middleware.validateZod(booksAPI.downloadBookFileSchema),
+  middleware.validateZod(BookValidators.downloadBookFileSchema),
   booksAPI.downloadBookFile,
 );
 
 router.route('/commons/book/:bookID/toc').get(
-  middleware.validateZod(booksAPI.getWithBookIDParamSchema),
+  middleware.validateZod(BookValidators.getWithBookIDParamSchema),
   booksAPI.getBookTOC,
 );
 
 router.route('/commons/book/:bookID/licensereport').get(
-  middleware.validateZod(booksAPI.getWithBookIDParamSchema),
+  middleware.validateZod(BookValidators.getWithBookIDParamSchema),
   booksAPI.getLicenseReport,
 );
 
 router.route('/commons/book/:bookID/peerreviews').get(
-  middleware.validateZod(booksAPI.getWithBookIDParamSchema),
+  middleware.validateZod(BookValidators.getWithBookIDParamSchema),
   booksAPI.getBookPeerReviews,
 );
 
@@ -669,7 +670,7 @@ router.route('/commons/catalogs/addresource').put(
   authAPI.verifyRequest,
   authAPI.getUserAttributes,
   authAPI.checkHasRoleMiddleware(process.env.ORG_ID, 'campusadmin'),
-  middleware.validateZod(booksAPI.getWithBookIDBodySchema),
+  middleware.validateZod(BookValidators.getWithBookIDBodySchema),
   booksAPI.addBookToCustomCatalog,
 );
 
@@ -677,7 +678,7 @@ router.route('/commons/catalogs/removeresource').put(
   authAPI.verifyRequest,
   authAPI.getUserAttributes,
   authAPI.checkHasRoleMiddleware(process.env.ORG_ID, 'campusadmin'),
-  middleware.validateZod(booksAPI.getWithBookIDBodySchema),
+  middleware.validateZod(BookValidators.getWithBookIDBodySchema),
   booksAPI.removeBookFromCustomCatalog,
 );
 

--- a/server/api/books.ts
+++ b/server/api/books.ts
@@ -63,6 +63,15 @@ import User from "../models/user.js";
 import centralIdentity from "./central-identity.js";
 const defaultImagesURL = "https://cdn.libretexts.net/DefaultImages";
 import { PipelineStage } from "mongoose";
+import {
+  createBookSchema,
+  getCommonsCatalogSchema,
+  getMasterCatalogSchema,
+  getWithBookIDParamSchema,
+  getWithBookIDBodySchema,
+  getBookFilesSchema,
+  downloadBookFileSchema,
+} from "../validators/book.js";
 
 const BOOK_PROJECTION: Partial<Record<keyof BookInterface, number>> = {
   _id: 0,
@@ -2125,69 +2134,6 @@ const retrieveKBExport = (_req: Request, res: Response) => {
     });
 };
 
-const createBookSchema = z.object({
-  body: z.object({
-    library: z.coerce.number().positive().int(),
-    title: z.string().min(1).max(255),
-    projectID: z.string().length(10),
-  }),
-});
-
-const getCommonsCatalogSchema = z.object({
-  query: z.object({
-    activePage: z.coerce.number().min(1).default(1),
-    limit: z.coerce.number().min(1).default(10),
-    sort: z
-      .union([z.literal("title"), z.literal("author"), z.literal("random")])
-      .optional()
-      .default("title"),
-  }),
-});
-
-const getMasterCatalogSchema = z.object({
-  query: z.object({
-    sort: z
-      .union([z.literal("title"), z.literal("author"), z.literal("random")])
-      .optional()
-      .default("title"),
-    search: z.string().min(1).optional(),
-  }),
-});
-
-const getWithBookIDParamSchema = z.object({
-  params: z.object({
-    bookID: z.string().refine(checkBookIDFormat, {
-      message: conductorErrors.err1,
-    }),
-  }),
-});
-
-const getWithBookIDBodySchema = z.object({
-  body: z.object({
-    bookID: z.string().refine(checkBookIDFormat, {
-      message: conductorErrors.err1,
-    }),
-  }),
-});
-
-const getBookFilesSchema = z.object({
-  params: z.object({
-    bookID: z.string().refine(checkBookIDFormat, {
-      message: conductorErrors.err1,
-    }),
-    fileID: z.string().uuid().optional(),
-  }),
-});
-
-const downloadBookFileSchema = z.object({
-  params: z.object({
-    bookID: z.string().refine(checkBookIDFormat, {
-      message: conductorErrors.err1,
-    }),
-    fileID: z.string().uuid(),
-  }),
-});
-
 export default {
   syncWithLibraries,
   runAutomatedSyncWithLibraries,
@@ -2205,11 +2151,4 @@ export default {
   getBookTOC,
   getLicenseReport,
   retrieveKBExport,
-  createBookSchema,
-  getCommonsCatalogSchema,
-  getMasterCatalogSchema,
-  getWithBookIDParamSchema,
-  getWithBookIDBodySchema,
-  getBookFilesSchema,
-  downloadBookFileSchema,
 };

--- a/server/api/validators/book.ts
+++ b/server/api/validators/book.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { checkBookIDFormat } from "../../util/bookutils";
+import conductorErrors from "../../conductor-errors";
+
+export const createBookSchema = z.object({
+    body: z.object({
+      library: z.coerce.number().positive().int(),
+      title: z.string().min(1).max(255),
+      projectID: z.string().length(10),
+    }),
+  });
+  
+  export const getCommonsCatalogSchema = z.object({
+    query: z.object({
+      activePage: z.coerce.number().min(1).default(1),
+      limit: z.coerce.number().min(1).default(10),
+      sort: z
+        .union([z.literal("title"), z.literal("author"), z.literal("random")])
+        .optional()
+        .default("title"),
+    }),
+  });
+  
+  export const getMasterCatalogSchema = z.object({
+    query: z.object({
+      sort: z
+        .union([z.literal("title"), z.literal("author"), z.literal("random")])
+        .optional()
+        .default("title"),
+      search: z.string().min(1).optional(),
+    }),
+  });
+  
+  export const getWithBookIDParamSchema = z.object({
+    params: z.object({
+      bookID: z.string().refine(checkBookIDFormat, {
+        message: conductorErrors.err1,
+      }),
+    }),
+  });
+  
+  export const getWithBookIDBodySchema = z.object({
+    body: z.object({
+      bookID: z.string().refine(checkBookIDFormat, {
+        message: conductorErrors.err1,
+      }),
+    }),
+  });
+  
+  export const getBookFilesSchema = z.object({
+    params: z.object({
+      bookID: z.string().refine(checkBookIDFormat, {
+        message: conductorErrors.err1,
+      }),
+      fileID: z.string().uuid().optional(),
+    }),
+  });
+  
+  export const downloadBookFileSchema = z.object({
+    params: z.object({
+      bookID: z.string().refine(checkBookIDFormat, {
+        message: conductorErrors.err1,
+      }),
+      fileID: z.string().uuid(),
+    }),
+  });
+
+ 


### PR DESCRIPTION
Moved zod validation schema in the books.ts file to a new separate book.ts file in the validators folder. Updated imports in the books.ts and api.js files accordingly. 