### PR TITLE
fix(Insight): featured article padding

### DIFF
--- a/client/src/components/kb/FeaturedList/FeaturedList.css
+++ b/client/src/components/kb/FeaturedList/FeaturedList.css
@@ -1,8 +1,7 @@
 .items-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 12rem);
-  justify-content: space-between;
-  grid-gap: 1rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
   padding-top: 0.5rem;
 }
 .featured-article-card {
@@ -13,7 +12,7 @@
   text-align: center;
   width: 18rem;
   height: 10rem;
-  padding: 0.5rem 0.3rem;
+  padding: 0.5rem 1rem;
   margin-right: 1.5rem;
   margin-bottom: 1.25rem;
   cursor: pointer;
@@ -34,7 +33,8 @@
   width: 20rem;
   height: 18rem;
   padding: 0.5rem;
-  margin-right: 1rem;
+  margin-right: 1.5rem;
+  margin-bottom: 1.25rem;
   cursor: pointer;
   border: 1px solid #e5e7eb;
   border-radius: 8px;

--- a/client/src/components/kb/FeaturedList/FeaturedPageCard.tsx
+++ b/client/src/components/kb/FeaturedList/FeaturedPageCard.tsx
@@ -38,11 +38,11 @@ const FeaturedPageCard = ({
           <Icon name="trash" size="small" />
         </div>
       )}
-      <div className="flex flex-col">
+      <div className="flex flex-col px-4">
         <p className="text-lg font-semibold flex-wrap">
           {truncateString(page.page.title, 50)}
         </p>
-        <p className="text-sm flex-wrap">{truncateString(page.page.description, 100)}</p>
+        <p className="text-sm flex-wrap my-1">{truncateString(page.page.description, 100)}</p>
       </div>
       <ConfirmDeleteFeaturedModal
         open={showDeleteModal}

--- a/client/src/components/kb/FeaturedList/FeaturedPageCard.tsx
+++ b/client/src/components/kb/FeaturedList/FeaturedPageCard.tsx
@@ -39,10 +39,10 @@ const FeaturedPageCard = ({
         </div>
       )}
       <div className="flex flex-col px-4">
-        <p className="text-lg font-semibold flex-wrap">
-          {truncateString(page.page.title, 50)}
+        <p className="text-lg font-semibold flex-wrap line-clamp-2">
+          {page.page.title}
         </p>
-        <p className="text-sm flex-wrap my-1">{truncateString(page.page.description, 100)}</p>
+        <p className="text-sm flex-wrap my-1 line-clamp-3">{page.page.description}</p>
       </div>
       <ConfirmDeleteFeaturedModal
         open={showDeleteModal}


### PR DESCRIPTION
Added padding to the featured article card to improve styling. Also noticed a layout issue when adding new cards, so I adjusted the items-list class to use flex instead of grid. (First photo shows the issue, second photo shows the fixed layout which is also responsive).
![Screenshot 2024-06-10 133343](https://github.com/LibreTexts/conductor/assets/73210740/8e4946d5-9ff2-4164-96ab-aa00302100ca)
![Screenshot 2024-06-10 135846](https://github.com/LibreTexts/conductor/assets/73210740/34b66650-f909-440c-b64a-7accec9ac2c0)
