### PR TITLE
fix(remixer): constrain remixer edits to the project's own book

### DIFF
--- a/server/api/remixer.ts
+++ b/server/api/remixer.ts
@@ -13,12 +13,14 @@ import PrejectRemixerJob from "../models/projectremixerjob.js";
 import base62 from "base62-random";
 import CXOnePageAPIEndpoints from "../util/CXOne/CXOnePageAPIEndpoints.js";
 import {
-  extractPagePath,
+  findUnownedRemixerPageIDs,
   getUserWorkbenchProjects,
 } from "../util/remixerutils";
 import { generateAPIRequestHeaders } from "../util/librariesclient.js";
 import User from "../models/user.js";
 import projectsAPI from "./projects.js";
+import BookService from "./services/book-service.js";
+import type { RemixerSubPageState } from "../models/projectremixer.js";
 
 class FetchPageError extends Error {
   statusCode: number;
@@ -52,6 +54,49 @@ const normalizeUpstreamErrorMessage = (message: string): string => {
   return trimmedMessage.slice(0, 300);
 };
 
+/**
+ * Verifies that a proposed remixer book only touches pages belonging to the
+ * project's own book (`${libreLibrary}-${libreCoverID}`). Returns a
+ * user-facing error message when the payload references content outside the
+ * book, or `null` when it is clean. Resolving the owned page set requires a
+ * live TOC lookup, so callers should treat a thrown/failed lookup as a reason
+ * to refuse (fail closed) rather than proceed.
+ */
+const validateRemixerBookOwnership = async (
+  libreLibrary: string | undefined,
+  libreCoverID: string | undefined,
+  currentBook: unknown,
+): Promise<string | null> => {
+  if (!libreLibrary || !libreCoverID) {
+    return "Project is not attached to a library book; cannot verify remixer permissions.";
+  }
+  const pages = (Array.isArray(currentBook) ? currentBook : []) as RemixerSubPageState[];
+  if (pages.length === 0) return null;
+
+  let ownedPageIDs: string[];
+  try {
+    const bookService = new BookService({
+      bookID: `${libreLibrary}-${libreCoverID}`,
+    });
+    ownedPageIDs = await bookService.getBookPageIDs();
+  } catch (error) {
+    console.error("[remixer] failed to resolve owned book pages:", error);
+    return "Unable to verify remixer permissions against the project's book.";
+  }
+  if (ownedPageIDs.length === 0) {
+    return "Unable to verify remixer permissions against the project's book.";
+  }
+
+  const { mutated, grafted } = findUnownedRemixerPageIDs(
+    pages,
+    new Set(ownedPageIDs),
+  );
+  if (mutated.length === 0 && grafted.length === 0) return null;
+
+  const count = mutated.length + grafted.length;
+  return `This remix references ${count} page(s) that do not belong to this project's book and cannot be saved or published.`;
+};
+
 const getRemixerProject = async (
   req: ZodReqWithUser<z.infer<typeof GetRemixerProjectStateSchema>>,
   res: Response,
@@ -68,11 +113,6 @@ const getRemixerProject = async (
   }
 
   const canAccess = projectsAPI.checkProjectMemberPermission(project, req.user);
-
-  // TODO: Remove these console logs after testing
-  console.log("[getRemixerProject] project:", project.projectID);
-  console.log("[getRemixerProject] user:", JSON.stringify(req.user));
-  console.log("[getRemixerProject] canAccess:", canAccess);
 
   if (!canAccess) {
     return res.status(403).send({
@@ -110,7 +150,7 @@ const saveRemixerProjectState = async (
 
   const project = await Project.findOne(
     { projectID: { $eq: id } },
-    { projectID: 1, _id: 0 },
+    { projectID: 1, libreLibrary: 1, libreCoverID: 1, _id: 0 },
   );
 
   if (!project) {
@@ -122,17 +162,23 @@ const saveRemixerProjectState = async (
 
   const canAccess = projectsAPI.checkProjectMemberPermission(project, req.user);
 
-  // TODO: Remove these console logs after testing
-  console.log("[saveRemixerProjectState] project:", project.projectID);
-  console.log("[saveRemixerProjectState] user:", JSON.stringify(req.user));
-  console.log("[saveRemixerProjectState] canAccess:", canAccess);
-
   if(!canAccess) {
     return res.status(403).send({
       err: true,
       errMsg: "You do not have permission to access this project",
     });
   }
+
+  // Never persist a book that references pages outside this project's book.
+  const ownershipError = await validateRemixerBookOwnership(
+    project.libreLibrary,
+    project.libreCoverID,
+    currentBook,
+  );
+  if (ownershipError) {
+    return res.status(403).send({ err: true, errMsg: ownershipError });
+  }
+
   // Check for an existing pending or running remixer job before allowing state save
   const existingJob = await PrejectRemixerJob.findOne({
     projectID: { $eq: id },
@@ -216,11 +262,6 @@ const publishRemixerProject = async (
 
   const canAccess = projectsAPI.checkProjectMemberPermission(project, req.user);
 
-  // TODO: Remove these console logs after testing
-  console.log("[publishRemixerProject] project:", project.projectID);
-  console.log("[publishRemixerProject] user:", JSON.stringify(req.user));
-  console.log("[publishRemixerProject] canAccess:", canAccess);
-
   if(!canAccess) {
     return res.status(403).send({
       err: true,
@@ -234,6 +275,18 @@ const publishRemixerProject = async (
       err: true,
       errMsg: "Project libreLibrary is missing",
     });
+  }
+
+  // Refuse before creating any state/job if the payload touches pages outside
+  // this project's book. runRemixerJob re-checks this authoritatively; doing it
+  // here gives immediate feedback and avoids spawning a doomed job.
+  const ownershipError = await validateRemixerBookOwnership(
+    subdomain,
+    project.libreCoverID,
+    currentBook,
+  );
+  if (ownershipError) {
+    return res.status(403).send({ err: true, errMsg: ownershipError });
   }
 
   const remixerState = await PrejectRemixer.findOneAndUpdate(
@@ -269,24 +322,6 @@ const publishRemixerProject = async (
     status: "pending",
     messages: ["Remixer job created."],
   });
-  const bookAPIURL: string = `https://${subdomain}.libretexts.org/@api/deki/pages/${project.libreCoverID ?? "home"}/${CXOnePageAPIEndpoints.GET_Page_Info}`;
-  const bookDetailsResponse = await fetch(bookAPIURL, {
-    headers: {
-      ...((await generateAPIRequestHeaders(subdomain)) ?? {}),
-    },
-  });
-  const bookDetails = await bookDetailsResponse.json();
-
-  let bookURL = bookDetails["uri.ui"];
-  bookURL = bookURL.replace(/\/+$/, "");
-  if (!bookURL) {
-    return res.status(400).send({
-      err: true,
-      errMsg: "Book URL not found",
-    });
-  }
-
-  const bookPath = extractPagePath(bookURL);
 
   remixerService
     .runRemixerJob({
@@ -336,11 +371,6 @@ const getRemixerProjectState = async (
   }
 
   const canAccess = projectsAPI.checkProjectMemberPermission(project, req.user);
-
-  // TODO: Remove these console logs after testing
-  console.log("[getRemixerProjectState] project:", project.projectID);
-  console.log("[getRemixerProjectState] user:", JSON.stringify(req.user));
-  console.log("[getRemixerProjectState] canAccess:", canAccess);
 
   if(!canAccess) {
     return res.status(403).send({
@@ -402,11 +432,6 @@ const deleteRemixerProjectState = async (
   }
 
   const canAccess = projectsAPI.checkProjectMemberPermission(project, req.user);
-
-  // TODO: Remove these console logs after testing
-  console.log("[deleteRemixerProjectState] project:", project.projectID);
-  console.log("[deleteRemixerProjectState] user:", JSON.stringify(req.user));
-  console.log("[deleteRemixerProjectState] canAccess:", canAccess);
 
   if(!canAccess) {
     return res.status(403).send({

--- a/server/api/remixer.ts
+++ b/server/api/remixer.ts
@@ -70,8 +70,30 @@ const validateRemixerBookOwnership = async (
   if (!libreLibrary || !libreCoverID) {
     return "Project is not attached to a library book; cannot verify remixer permissions.";
   }
-  const pages = (Array.isArray(currentBook) ? currentBook : []) as RemixerSubPageState[];
-  if (pages.length === 0) return null;
+  if (!Array.isArray(currentBook)) {
+    return "Malformed remixer book payload; cannot verify remixer permissions.";
+  }
+  if (currentBook.length === 0) return null;
+
+  // The Zod schema accepts `record<string, any>` entries, so the shape the
+  // ownership check relies on is not yet guaranteed. Validate it here (rather
+  // than trusting the cast) so a malformed node fails closed with a clear
+  // authorization error instead of throwing a 500 deep inside the check.
+  const isValidNode = (node: unknown): node is RemixerSubPageState => {
+    if (typeof node !== "object" || node === null) return false;
+    const record = node as Record<string, unknown>;
+    if (typeof record["@id"] !== "string" || record["@id"].length === 0) {
+      return false;
+    }
+    if (record.parentID !== undefined && typeof record.parentID !== "string") {
+      return false;
+    }
+    return true;
+  };
+  if (!currentBook.every(isValidNode)) {
+    return "Remixer book contains malformed pages; cannot verify remixer permissions.";
+  }
+  const pages = currentBook as RemixerSubPageState[];
 
   let ownedPageIDs: string[];
   try {

--- a/server/api/services/remixer-service.ts
+++ b/server/api/services/remixer-service.ts
@@ -1146,6 +1146,16 @@ const toFinalBookEntry = (
   };
 };
 
+/**
+ * Renders a bounded preview of offending page IDs for an error/log message.
+ * A malicious payload can carry thousands of out-of-book IDs; we always report
+ * the full count but cap the enumerated list so the message can't blow up logs.
+ */
+const previewPageIDs = (ids: string[], limit = 20): string => {
+  if (ids.length <= limit) return ids.join(", ");
+  return `${ids.slice(0, limit).join(", ")}, …and ${ids.length - limit} more`;
+};
+
 const runRemixerJob = async ({
   jobID,
   projectID,
@@ -1204,12 +1214,12 @@ const runRemixerJob = async ({
       const parts: string[] = [];
       if (mutated.length > 0) {
         parts.push(
-          `${mutated.length} page(s) outside this book flagged for edit/delete (${mutated.join(", ")})`,
+          `${mutated.length} page(s) outside this book flagged for edit/delete (${previewPageIDs(mutated)})`,
         );
       }
       if (grafted.length > 0) {
         parts.push(
-          `${grafted.length} new/imported page(s) not anchored in this book (${grafted.join(", ")})`,
+          `${grafted.length} new/imported page(s) not anchored in this book (${previewPageIDs(grafted)})`,
         );
       }
       throw new Error(

--- a/server/api/services/remixer-service.ts
+++ b/server/api/services/remixer-service.ts
@@ -16,6 +16,8 @@ import {
   buildRemixerPagePathSegment,
   extractLibretextsSubdomain,
   extractPagePath,
+  findUnownedRemixerPageIDs,
+  getPageStatus,
 } from "../../util/remixerutils";
 import * as cheerio from "cheerio";
 import { log } from "debug";
@@ -458,25 +460,6 @@ const getDisplayTitle = (
     ? `${formattedPath}: ${cleanTitle}`
     : cleanTitle;
   return appendSiblingTitleSuffix(titleWithPath, page);
-};
-
-type PageStatus = "unchaned" | "modeified" | "new" | "imported" | "deleted";
-
-const getPageStatus = (page: RemixerSubPageState): PageStatus => {
-  if (page.isDeleted) return "deleted";
-  if (page.addedItem && !page.isDeleted && page["@id"].startsWith("new-"))
-    return "new";
-
-  if (page.isImported || page.addedItem) return "imported";
-  if (
-    page.movedItem ||
-    page.isPlacementChanged ||
-    page.movedItem ||
-    page.renamedItem
-  )
-    return "modeified";
-
-  return "unchaned";
 };
 
 const applyDefaultRemixerPageProperties = async (
@@ -1189,6 +1172,51 @@ const runRemixerJob = async ({
     }
 
     const pages = remixerState.remixerCurrentBook;
+
+    // ── Ownership gate ───────────────────────────────────────────────────────
+    // Every mutation this job performs is keyed on client-supplied page IDs.
+    // Before touching the library, confirm that no page outside THIS project's
+    // book is moved/renamed/deleted, and that no new/imported content is
+    // grafted onto a page the project doesn't own. Fail closed on any breach.
+    // Book identity is `${subdomain}-${coverId}` (server-derived from the
+    // project), the definitive source of truth per redirect/path caveats.
+    let ownedPageIDs: string[];
+    try {
+      const bookService = new BookService({ bookID: `${subdomain}-${coverId}` });
+      ownedPageIDs = await bookService.getBookPageIDs();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Unable to resolve the project's book contents for authorization; refusing to publish (${detail}).`,
+      );
+    }
+    if (ownedPageIDs.length === 0) {
+      // A published book always resolves at least its cover page. An empty set
+      // means the TOC lookup failed silently — do not treat "nothing owned" as
+      // permission to skip the check.
+      throw new Error(
+        "Could not resolve any pages for the project's book; refusing to publish.",
+      );
+    }
+    const ownedIDs = new Set(ownedPageIDs);
+    const { mutated, grafted } = findUnownedRemixerPageIDs(pages, ownedIDs);
+    if (mutated.length > 0 || grafted.length > 0) {
+      const parts: string[] = [];
+      if (mutated.length > 0) {
+        parts.push(
+          `${mutated.length} page(s) outside this book flagged for edit/delete (${mutated.join(", ")})`,
+        );
+      }
+      if (grafted.length > 0) {
+        parts.push(
+          `${grafted.length} new/imported page(s) not anchored in this book (${grafted.join(", ")})`,
+        );
+      }
+      throw new Error(
+        `Refusing to publish: the remix references content outside this project's book — ${parts.join("; ")}.`,
+      );
+    }
+
     const copyModeState = normalizeRemixerCopyMode(remixerState.copyModeState);
     const byId = new Map(pages.map((p) => [p["@id"], p]));
 

--- a/server/util/remixerutils.ts
+++ b/server/util/remixerutils.ts
@@ -112,12 +112,7 @@ export const getPageStatus = (page: RemixerSubPageState): RemixerPageStatus => {
     return "new";
 
   if (page.isImported || page.addedItem) return "imported";
-  if (
-    page.movedItem ||
-    page.isPlacementChanged ||
-    page.movedItem ||
-    page.renamedItem
-  )
+  if (page.movedItem || page.isPlacementChanged || page.renamedItem)
     return "modeified";
 
   return "unchaned";

--- a/server/util/remixerutils.ts
+++ b/server/util/remixerutils.ts
@@ -1,4 +1,5 @@
 import Project from "../models/project";
+import type { RemixerSubPageState } from "../models/projectremixer";
 
 export const slugifyNode =(title:string): string =>{
  
@@ -92,3 +93,93 @@ export const getUserWorkbenchProjects = async (subdomain: string, userId: string
 
   return projects.map((project) => project.libreCoverID);
 }
+
+export type RemixerPageStatus =
+  | "unchaned"
+  | "modeified"
+  | "new"
+  | "imported"
+  | "deleted";
+
+/**
+ * Classifies what the remixer job will do with a page, from the client-supplied
+ * change-tracking flags. Lives here (rather than in remixer-service) so the
+ * ownership validator and the job can share one source of truth.
+ */
+export const getPageStatus = (page: RemixerSubPageState): RemixerPageStatus => {
+  if (page.isDeleted) return "deleted";
+  if (page.addedItem && !page.isDeleted && page["@id"].startsWith("new-"))
+    return "new";
+
+  if (page.isImported || page.addedItem) return "imported";
+  if (
+    page.movedItem ||
+    page.isPlacementChanged ||
+    page.movedItem ||
+    page.renamedItem
+  )
+    return "modeified";
+
+  return "unchaned";
+};
+
+/**
+ * Security gate for the remixer: given a proposed book (the client-supplied
+ * `remixerCurrentBook`) and the set of page IDs that genuinely belong to the
+ * project's book (resolved from the live cover TOC via
+ * `BookService.getBookPageIDs()`), returns the page IDs that fall outside the
+ * book and therefore must NOT be touched.
+ *
+ * Two distinct violations are reported:
+ *  - `mutated`: an existing page (numeric `@id`) flagged for in-place
+ *    move/rename/delete whose `@id` is not in the owned set. This is the
+ *    cross-book IDOR — deleting or moving another project's pages.
+ *  - `grafted`: a newly created / imported node whose parent chain does not
+ *    anchor on an owned in-book page (the cover or an existing book page),
+ *    i.e. an attempt to attach new content into a book the user doesn't own.
+ *
+ * Page IDs are compared as strings; the caller decides the failure policy
+ * (this project fails the whole job closed when either array is non-empty).
+ * Note: an imported node's own `@id` is the SOURCE page's id (from another
+ * library) and is intentionally never required to be in `ownedIDs` — only its
+ * anchor parent is checked.
+ */
+export const findUnownedRemixerPageIDs = (
+  pages: RemixerSubPageState[],
+  ownedIDs: Set<string>,
+): { mutated: string[]; grafted: string[] } => {
+  const mutated: string[] = [];
+  const grafted: string[] = [];
+  const byId = new Map(pages.map((p) => [p["@id"], p]));
+
+  // A creation is legitimately rooted if, climbing its parentID chain (through
+  // other in-payload nodes), we reach a parent that is an owned in-book page
+  // (the cover qualifies — getBookPageIDs includes it). Reaching the top ("-1")
+  // or an external, non-owned parent means the subtree isn't in this book.
+  const isAnchoredInBook = (page: RemixerSubPageState): boolean => {
+    const seen = new Set<string>();
+    let current = page.parentID ?? "-1";
+    while (current && current !== "-1") {
+      if (ownedIDs.has(current)) return true;
+      if (!byId.has(current)) return false; // external, non-owned parent
+      if (seen.has(current)) return false; // cycle guard
+      seen.add(current);
+      current = byId.get(current)!.parentID ?? "-1";
+    }
+    return false;
+  };
+
+  for (const page of pages) {
+    const status = getPageStatus(page);
+    if (status === "modeified" || status === "deleted") {
+      const id = page["@id"];
+      // `new-` ids are never mutated in place by the job handlers.
+      if (id.startsWith("new-")) continue;
+      if (!ownedIDs.has(id)) mutated.push(id);
+    } else if (status === "new" || status === "imported") {
+      if (!isAnchoredInBook(page)) grafted.push(page["@id"]);
+    }
+  }
+
+  return { mutated, grafted };
+};


### PR DESCRIPTION
The remixer applied the client-supplied remixerCurrentBook to the live library, authorized only by project membership. Nothing verified that the page @ids belonged to the project's book, so a member of one project could craft a payload to make changes in an unrelated book in the same library.

Add an ID-based ownership gate keyed on `${libreLibrary}-${libreCoverID}`, resolved from the live cover TOC via BookService.getBookPageIDs(). New helper findUnownedRemixerPageIDs flags in-place mutations (move/rename/ delete) whose @id is outside the book and new/imported nodes not anchored on an owned page. Enforced fail-closed in runRemixerJob (authoritative) and rejected early in publishRemixerProject and saveRemixerProjectState. Uses page-ID membership rather than path prefixes, which are unreliable due to CXOne redirects and variable path depth.

Also lift getPageStatus into remixerutils for shared use, remove unused debug logs, and drop the unused bookURL/bookPath
fetch in publishRemixerProject.