### PR TITLE
fix(Remixer): tighten path format validation

### DIFF
--- a/client/src/components/remixer/PathNameFormat.tsx
+++ b/client/src/components/remixer/PathNameFormat.tsx
@@ -81,7 +81,7 @@ const PathNameFormat: React.FC<PathNameFormatProps> = (props) => {
         const level = format.level;
         const token = getStartToken(format.start, format.type);
         const tokenExists = token.trim().length > 0;
-        const prefix = format.prefix ?? "";
+        const prefix = typeof format.prefix === "string" ? format.prefix : "";
 
         if (format.excludeParent) {
           if (tokenExists) {
@@ -201,7 +201,7 @@ const PathNameFormat: React.FC<PathNameFormatProps> = (props) => {
                       placeholder="Type or choose a prefix…"
                       className="w-full mt-1.5"
                       onChange={(e) =>
-                        updateLevelFormat(index, "prefix", e.target.value)
+                        updateLevelFormat(index, "prefix", String(e.target.value ?? ""))
                       }
                     />
                     <Text size="xs" className="mt-1 text-neutral-500">

--- a/client/src/components/remixer/services.ts
+++ b/client/src/components/remixer/services.ts
@@ -294,7 +294,7 @@ export const splitFormattedPathParts = (
     const value = start + parsePathSegmentOrdinal(segment) - 1;
     const token = getFormattedTokenByType(value, type);
     const tokenExists = token.trim().length > 0;
-    const levelPrefix = format?.prefix ?? "";
+    const levelPrefix = typeof format?.prefix === "string" ? format.prefix : "";
 
     if (format?.excludeParent) {
       if (tokenExists) {

--- a/server/api/validators/remixer.ts
+++ b/server/api/validators/remixer.ts
@@ -26,7 +26,26 @@ export const SaveRemixerProjectStateSchema = z.object({
   }),
   body: z.object({
     currentBook: z.array(z.record(z.string(), z.any())),
-    pathLevelFormats: z.array(z.record(z.string(), z.any())),
+    pathLevelFormats: z.array(
+      z
+        .object({
+          level: z.number(),
+          prefix: z.string().default(""),
+          start: z.number().default(1),
+          type: z.enum([
+            "numeric",
+            "alphabetic",
+            "alphabetic_lower",
+            "roman",
+            "roman_lower",
+            "none",
+          ]),
+          delimiter: z.string().optional(),
+          excludeParent: z.boolean().optional(),
+          continue: z.boolean().optional(),
+        })
+        .passthrough(),
+    ),
     autoNumbering: z.boolean().optional(),
     copyModeState: z.string().optional(),
   }),

--- a/server/migrations/StripObjectObjectFromRemixerPaths.ts
+++ b/server/migrations/StripObjectObjectFromRemixerPaths.ts
@@ -1,0 +1,107 @@
+import PrejectRemixer, {
+  PathLevelFormatState,
+  RemixerSubPageState,
+} from "../models/projectremixer.js";
+
+/**
+ * Repairs remixer states corrupted by a non-string `pathLevelFormats[].prefix`.
+ *
+ * A level format prefix that arrived as an object was cast by Mongoose's
+ * `String` schema type to the literal `"[object Object]"` on save. That string
+ * then flowed into every level-1 node's `formattedPath` (e.g. `"[object Object]1"`)
+ * because path building concatenates `prefix + index`.
+ *
+ * This migration strips the `"[object Object]"` marker wherever it was persisted:
+ *   - `pathLevelFormats[].prefix`  → "" (falls back to no prefix)
+ *   - each book node's `formattedPath` → marker removed (e.g. "[object Object]1" → "1")
+ *
+ * Removing the marker from `formattedPath` is safe for both auto-numbered and
+ * overridden nodes: for auto-numbered nodes the client recomputes the value from
+ * `pathNumber` on the next load anyway; for overrides it preserves the real
+ * index/suffix the user entered while dropping only the corrupted prefix.
+ */
+
+const MARKER = "[object Object]";
+
+export async function runMigration() {
+  try {
+    const states = await PrejectRemixer.find({}).lean();
+
+    const toUpdate: {
+      _id: unknown;
+      remixerCurrentBook: RemixerSubPageState[];
+      pathLevelFormats: PathLevelFormatState[];
+    }[] = [];
+
+    for (const state of states) {
+      let changed = false;
+
+      const pathLevelFormats = Array.isArray(state.pathLevelFormats)
+        ? state.pathLevelFormats.map((format) => {
+            if (
+              format &&
+              typeof format.prefix === "string" &&
+              format.prefix.includes(MARKER)
+            ) {
+              changed = true;
+              return { ...format, prefix: format.prefix.split(MARKER).join("") };
+            }
+            return format;
+          })
+        : state.pathLevelFormats;
+
+      const remixerCurrentBook = Array.isArray(state.remixerCurrentBook)
+        ? state.remixerCurrentBook.map((node) => {
+            if (
+              node &&
+              typeof node.formattedPath === "string" &&
+              node.formattedPath.includes(MARKER)
+            ) {
+              changed = true;
+              return {
+                ...node,
+                formattedPath: node.formattedPath.split(MARKER).join(""),
+              };
+            }
+            return node;
+          })
+        : state.remixerCurrentBook;
+
+      if (!changed) continue;
+
+      console.log(
+        `Repairing remixer state for project ${state.projectID} (remixerID ${state.remixerID}).`,
+      );
+
+      toUpdate.push({
+        _id: state._id,
+        remixerCurrentBook: remixerCurrentBook as RemixerSubPageState[],
+        pathLevelFormats: pathLevelFormats as PathLevelFormatState[],
+      });
+    }
+
+    console.log(`Found ${toUpdate.length} remixer state(s) to repair.`);
+
+    const chunkSize = 25;
+    for (let i = 0; i < toUpdate.length; i += chunkSize) {
+      const chunk = toUpdate.slice(i, i + chunkSize);
+      const bulkOps = chunk.map((state) => ({
+        updateOne: {
+          filter: { _id: state._id },
+          update: {
+            $set: {
+              remixerCurrentBook: state.remixerCurrentBook,
+              pathLevelFormats: state.pathLevelFormats,
+            },
+          },
+        },
+      }));
+
+      await PrejectRemixer.bulkWrite(bulkOps);
+    }
+
+    console.log("Remixer path repair migration complete.");
+  } catch (err) {
+    console.error("Error during migration: ", err);
+  }
+}


### PR DESCRIPTION
In short an un-coerced object slipped into a level format's prefix, Mongoose stringified it to "[object Object]", and that string got concatenated into formattedPath for the top-level nodes.

The migration is a one-off in case any existing data needs to be corrected, but it's unlikely we need to run it at all