### PR TITLE
feat(remixer): "Update Benny" — on-demand chatbot re-ingest after editing a page

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -550,6 +550,24 @@ class API {
   }
 
   /**
+   * Ask the LibreTexts chatbot (Benny) to re-ingest a single page now, rather
+   * than waiting for its periodic sweep. Use after an author edits the page in
+   * the library. Streams pipeline progress (SSE): fetched -> chunked ->
+   * embedded -> indexed -> done | error.
+   * @param {string} bookID - `${library}-${coverPageID}` of the book
+   * @param {string} pageID - the CXOne page id being refreshed
+   */
+  reingestPage(bookID: string, pageID: string) {
+    return new EventSource(
+      `${this.BASE_URL}/reingest/books/${bookID}/pages/${pageID}`,
+      {
+        withCredentials: true,
+        method: "POST",
+      },
+    );
+  }
+
+  /**
    * Applies user-supplied summaries and tags to the respective pages in a book
    * @param {string} bookID - the cover page of the book to apply the metadata to
    * @param {Array<{ id: string; summary: string; tags: string[] }>} pages - the pages & data to update

--- a/client/src/components/remixer/EditPanel.tsx
+++ b/client/src/components/remixer/EditPanel.tsx
@@ -3,6 +3,7 @@ import {    Icon, Modal } from "semantic-ui-react";
 import { Library, RemixerSubPage } from "./model";
 import { Button, Checkbox, Input, Stack } from "@libretexts/davis-react";
 import { DAVIS_REMIXER_BTN_CLASS, DAVIS_REMIXER_CHECKBOX_CLASS, DAVIS_REMIXER_LINK_CLASS } from "./style";
+import api from "../../api";
 
 interface EditPanelProps {
   open: boolean;
@@ -12,7 +13,13 @@ interface EditPanelProps {
   handleSave: (page: RemixerSubPage) => void;
   formattedPathDefault?: string;
   library:Library;
+  coverID?: string;
 }
+
+type ReingestState = {
+  status: "idle" | "running" | "done" | "error";
+  message: string;
+};
 
 /** Colons are not allowed. If present, drop the prefix before the first ":" and any remaining ":". */
 function sanitizeRemixerTitle(value: string, trim: boolean = true): string {
@@ -35,9 +42,68 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
     currentPage,
     handleSave,
     formattedPathDefault,
-    library
+    library,
+    coverID
   } = props;
   const [page, setPage] = useState<RemixerSubPage | undefined>(currentPage);
+  const [reingest, setReingest] = useState<ReingestState>({
+    status: "idle",
+    message: "",
+  });
+
+  // Reset the re-ingest status whenever the panel opens on a different page.
+  useEffect(() => {
+    setReingest({ status: "idle", message: "" });
+  }, [currentPage, open]);
+
+  const handleReingest = () => {
+    const pageID = currentPage?.["@id"];
+    if (!pageID || !coverID || !library) return;
+
+    setReingest({ status: "running", message: "Starting…" });
+    const evtSource = api.reingestPage(`${library}-${coverID}`, pageID);
+
+    evtSource.addEventListener("progress", (e: MessageEvent) => {
+      try {
+        const d = JSON.parse(e.data);
+        const label: Record<string, string> = {
+          fetched: "Fetched the latest content",
+          chunked: `Split into ${d.chunks} sections`,
+          embedded: `Updated ${d.units_novel} of ${d.units_total} changed sections`,
+          indexed: "Indexing",
+        };
+        setReingest({ status: "running", message: label[d.stage] ?? d.stage });
+      } catch {
+        /* ignore an unparseable frame */
+      }
+    });
+
+    evtSource.addEventListener("done", (e: MessageEvent) => {
+      let message = "Benny is up to date with this page.";
+      try {
+        const d = JSON.parse(e.data);
+        message = `Benny is up to date (${d.chunks} sections).`;
+      } catch {
+        /* keep the default */
+      }
+      setReingest({ status: "done", message });
+      evtSource.close();
+    });
+
+    // NOTE: SSE dispatches our `event: error` frame AND native transport errors
+    // to the same "error" listener. Our failure frame carries JSON data; a
+    // transport error does not — disambiguate on that.
+    evtSource.addEventListener("error", (e: MessageEvent) => {
+      let message = "Couldn't reach Benny — try again in a moment.";
+      try {
+        if (e?.data) message = JSON.parse(e.data).message ?? message;
+      } catch {
+        /* keep the default */
+      }
+      setReingest({ status: "error", message });
+      evtSource.close();
+    });
+  };
 
   const handleSaveClick = () => {
     if (!page) return;
@@ -127,6 +193,34 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
             Link to this page in the library
             <Icon name="external alternate" className="!ml-2" />
           </a>
+        )}
+        {!currentPage?.["@id"].startsWith("new-") && coverID && (
+          <div className="!mt-4">
+            <Button
+              onClick={handleReingest}
+              disabled={reingest.status === "running"}
+              className={DAVIS_REMIXER_BTN_CLASS.base}
+            >
+              {reingest.status === "running"
+                ? "Updating Benny…"
+                : "Update Benny for this page"}
+            </Button>
+            <p className="!mt-1 !text-sm !text-gray-600">
+              After editing this page in the library, refresh Benny's copy so
+              students see your changes now — or leave it for the weekly sync.
+            </p>
+            {reingest.message && (
+              <p
+                className={
+                  reingest.status === "error"
+                    ? "!mt-1 !text-sm !text-red-600"
+                    : "!mt-1 !text-sm !text-gray-700"
+                }
+              >
+                {reingest.message}
+              </p>
+            )}
+          </div>
         )}
       </Modal.Content>
       <Modal.Actions>

--- a/client/src/components/remixer/RemixerDashboard.tsx
+++ b/client/src/components/remixer/RemixerDashboard.tsx
@@ -2311,6 +2311,7 @@ const RemixerDashboard: React.FC = () => {
           currentPage={selectedBookNode}
           handleSave={handleSaveEdit}
           library={remixerData.libreLibrary as Library}
+          coverID={remixerData.liberCoverID}
         />
       )}
       <PathNameFormat

--- a/server/api.js
+++ b/server/api.js
@@ -13,6 +13,7 @@ import assetTagFrameworkAPI from "./api/assettagframeworks.js";
 import authorsAPI from "./api/authors.js";
 import authAPI from "./api/auth.js";
 import coAuthorAPI from "./api/co-author.js";
+import reingestAPI from "./api/reingest.js";
 import storeAPI from "./api/store.js";
 import centralIdentityAPI from "./api/central-identity.js";
 import clientConfigAPI from "./api/client-config.js";
@@ -53,6 +54,7 @@ import * as LibraryValidators from "./api/validators/libraries.js";
 import * as supportValidators from "./api/validators/support.js";
 import * as supportQueueValidators from "./api/validators/supportqueues.js";
 import * as ProjectValidators from "./api/validators/projects.js";
+import * as reingestValidators from "./api/validators/reingest.js";
 import * as ProjectFileValidators from "./api/validators/projectfiles.js";
 import * as SearchValidators from "./api/validators/search.js";
 import * as AssetTagFrameworkValidators from "./api/validators/assettagframeworks.js";
@@ -1351,6 +1353,16 @@ router
 router
   .route("/commons/homework/sync/automated")
   .put(middleware.checkLibreAPIKey, homeworkAPI.runAutomatedHomeworkSync);
+
+/* Benny re-ingest (LibreTexts chatbot) */
+router
+  .route("/reingest/books/:bookID/pages/:pageID")
+  .post(
+    authAPI.verifyRequest,
+    authAPI.getUserAttributes,
+    middleware.validateZod(reingestValidators.reingestPageSchema),
+    reingestAPI.reingestPage
+  );
 
 /* Coauthor */
 router

--- a/server/api/reingest.ts
+++ b/server/api/reingest.ts
@@ -1,0 +1,105 @@
+import { Response } from "express";
+import { z } from "zod";
+import axios from "axios";
+import { ZodReqWithUser } from "../types";
+import BookService from "./services/book-service";
+import { getLibraryAndPageFromBookID } from "../util/bookutils.js";
+import conductorErrors from "../conductor-errors";
+import { conductor404Err, conductor500Err } from "../util/errorutils";
+import { debugError } from "../debug";
+import { reingestPageSchema } from "./validators/reingest";
+
+const CHATBOT_URL = process.env.CHATBOT_REINGEST_URL;
+const CHATBOT_KEY = process.env.CHATBOT_REINGEST_SERVICE_KEY;
+
+/**
+ * Ask the LibreTexts chatbot (Benny) to re-ingest a single page immediately,
+ * rather than waiting for its periodic sweep. Offered to an author after they
+ * edit a page in the library. Streams the chatbot's own pipeline progress (SSE)
+ * straight back to the client — fetched -> chunked -> embedded -> indexed -> done.
+ *
+ * Trust model: the chatbot service key is held server-side and never reaches the
+ * browser. Reaching this route means an authenticated Conductor user who can edit
+ * the page (re-checked here via canAccessPage). The chatbot trusts our key; we
+ * verify the human. It does not authorize the author itself, and it never learns
+ * the author's identity — attribution of *who* stays here in Conductor.
+ *
+ * Re-ingest is idempotent and cheap when nothing changed (content is
+ * hash-addressed downstream), so offering it broadly is safe.
+ */
+async function reingestPage(
+  req: ZodReqWithUser<z.infer<typeof reingestPageSchema>>,
+  res: Response
+) {
+  try {
+    if (!CHATBOT_URL || !CHATBOT_KEY) {
+      return res.status(503).send({
+        err: true,
+        errMsg: "Benny re-ingest is not configured on this environment.",
+      });
+    }
+
+    const { bookID, pageID } = req.params;
+    const [library, coverID] = getLibraryAndPageFromBookID(bookID);
+    if (!library || !coverID) return conductor404Err(res);
+
+    // Defense in depth: the user reached the editor via project membership, but
+    // re-confirm they may edit THIS page before vouching to the chatbot.
+    const bookService = new BookService({ bookID });
+    const canAccess = await bookService.canAccessPage(
+      req.user.decoded.uuid,
+      pageID
+    );
+    if (!canAccess) {
+      return res.status(403).send({ err: true, errMsg: conductorErrors.err8 });
+    }
+
+    const upstream = await axios.post(
+      `${CHATBOT_URL}/api/pages/${encodeURIComponent(pageID)}/reingest`,
+      undefined,
+      {
+        params: { library },
+        headers: {
+          "X-Reingest-Service-Key": CHATBOT_KEY,
+          Accept: "text/event-stream",
+        },
+        responseType: "stream",
+        validateStatus: () => true, // handle non-200 ourselves
+      }
+    );
+
+    // Resolution errors (404 not-ingested / 429 busy / 401 / 503) arrive as JSON
+    // before any stream opens — forward the status and message.
+    if (upstream.status !== 200) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of upstream.data) chunks.push(chunk as Buffer);
+      let errMsg = `Benny re-ingest failed (${upstream.status}).`;
+      try {
+        const parsed = JSON.parse(Buffer.concat(chunks).toString());
+        if (parsed?.detail) errMsg = parsed.detail;
+      } catch {
+        /* non-JSON body; keep the generic message */
+      }
+      return res.status(upstream.status).send({ err: true, errMsg });
+    }
+
+    // Same SSE frame format the client already consumes — pipe it through.
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+
+    upstream.data.pipe(res);
+    upstream.data.on("end", () => res.end());
+    // Client went away mid-stream — stop pulling from the chatbot.
+    res.on("close", () => {
+      upstream.data.destroy?.();
+    });
+  } catch (e) {
+    debugError(e);
+    if (!res.headersSent) return conductor500Err(res);
+    res.end();
+  }
+}
+
+export default { reingestPage };

--- a/server/api/validators/reingest.ts
+++ b/server/api/validators/reingest.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+/**
+ * Params for the on-demand Benny re-ingest proxy.
+ * bookID is `${library}-${coverPageID}`; pageID is the CXOne page id.
+ */
+export const reingestPageSchema = z.object({
+  params: z.object({
+    bookID: z.string().min(1),
+    pageID: z.string().min(1),
+  }),
+});


### PR DESCRIPTION
## What

Adds an **"Update Benny for this page"** button to the Remixer's Edit Panel. After
an author edits a page in the library, they can refresh the LibreTexts chatbot
(Benny)'s copy of that page immediately, instead of waiting for its ~weekly
freshness sweep. The panel already links out to edit the page in the library — the
button sits right beside that link.

Re-ingest is **optional and idempotent**: it's an optimization over the sweep, and
re-ingesting an unchanged page re-embeds nothing. So the button is offered to
anyone who can already reach the editor; there's nothing to lose by clicking it.

## How

- **Server** — a thin proxy route, `POST /reingest/books/:bookID/pages/:pageID`:
  - `verifyRequest` + `getUserAttributes` (normal auth), then re-checks the author
    may edit the page via `bookService.canAccessPage`;
  - holds the chatbot service key **server-side** and calls the chatbot's
    re-ingest endpoint;
  - pipes the chatbot's SSE progress straight back to the client.

  The key never reaches the browser. The chatbot trusts our key; we verify the
  human. Conductor sends **no author identity** to the chatbot — attribution of
  *who* stays here.

- **Client** — `api.reingestPage()` opens the stream; `EditPanel` renders the
  pipeline stages (fetched → chunked → embedded → indexed → done) and surfaces
  "N of M changed sections" as the outcome.

## Configuration — two server env vars

Injected at runtime the same way as `OPENAI_API_KEY` / `QDRANT_API_KEY`
(`process.env`, not baked into the image, not SSM):

| var | example | notes |
|---|---|---|
| `CHATBOT_REINGEST_URL` | `https://chatbot.libretexts.org` | the chatbot API base |
| `CHATBOT_REINGEST_SERVICE_KEY` | *(secret)* | shared secret, provided out-of-band by the chatbot team; dedicated to re-ingest (distinct from any read key) |

**Unset on an environment → the route returns `503` and the button reports it;
nothing else is affected.** Safe to merge before the secret is provisioned.

## Notes for review

- No new npm dependencies (`axios`, `better-sse`, `zod` already present); no
  `package-lock.json` changes.
- Verified against the repo's build gates locally: `server` `npm run build`
  (tsup `--dts`) succeeds; `client` `tsc --noEmit` is clean.
- The chatbot endpoint's contract (frame format, status codes) is documented on
  the chatbot side; this PR consumes it.
- Placement (Remixer Edit Panel) was chosen because it's where an author already
  goes to reach the page's library editor. Happy to move it if there's a better
  per-page surface.
