### PR TITLE
refactor(remixer): simplify title sanitization logic in EditPanel component

### DIFF
--- a/client/src/components/remixer/EditPanel.tsx
+++ b/client/src/components/remixer/EditPanel.tsx
@@ -30,13 +30,7 @@ function sanitizeRemixerTitle(
   trim: boolean = true,
   allowColon = false,
 ): string {
-  let s = value;
-  if (!allowColon) {
-    const colonIdx = value.indexOf(":");
-    if (colonIdx !== -1) {
-      s = value.slice(colonIdx + 1);
-    }
-  }
+  const s = allowColon ? value : value.replace(/:/g, "-");
   return trim ? s.trim() : s;
 }
 

--- a/client/src/components/remixer/EditPanel.tsx
+++ b/client/src/components/remixer/EditPanel.tsx
@@ -11,7 +11,12 @@ import {
   IconButton,
 } from "@libretexts/davis-react";
 import { IconDeviceFloppy, IconEdit } from "@tabler/icons-react";
-import { getRemixerPageUriUi } from "./services";
+import {
+  getRemixerPageUriUi,
+  isRemixerBookRoot,
+  sanitizeRemixerPageTitle,
+  toEditableRemixerTitle,
+} from "./services";
 
 interface EditPanelProps {
   open: boolean;
@@ -21,17 +26,8 @@ interface EditPanelProps {
   /** Auto-numbered prefix/index pieces used as placeholders/defaults when override is first enabled. */
   formattedPathPartsDefault?: { prefix: string; index: string };
   library: Library;
-  /** True when editing the top-level book node; colons are allowed in book titles. */
+  /** Project cover page id; the book root allows colons in its title. */
   coverPageId: string;
-}
-
-function sanitizeRemixerTitle(
-  value: string,
-  trim: boolean = true,
-  allowColon = false,
-): string {
-  const s = allowColon ? value : value.replace(/:/g, "-");
-  return trim ? s.trim() : s;
 }
 
 /** Truncate to `maxLen` characters with "..." in the middle (e.g. 25 → "abcdefghij...opqrstuvwxy"). */
@@ -68,8 +64,7 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
     : "";
  
   const titleInputRef = useRef<HTMLInputElement>(null);
-  const isBookRoot =
-    currentPage?.parentID === "-1" || currentPage?.["@id"] === coverPageId;
+  const isBookRoot = isRemixerBookRoot(currentPage, coverPageId);
   const [overrideUriUiEnding, setOverrideUriUiEnding] = useState<string|undefined>(
     sanitizeUriEnding(currentPage?.overrideUriUiEnding ||currentPageUri?.split("/").slice(-1)[0]  ||undefined),
   );
@@ -78,9 +73,8 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
 
   const handleSaveClick = () => {
     if (!page) return;
-    const title = sanitizeRemixerTitle(
+    const title = toEditableRemixerTitle(
       page.title ?? page["@title"] ?? "",
-      true,
       isBookRoot,
     );
     const overridden = page.formattedPathOverride === true;
@@ -104,9 +98,8 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
       setPage(undefined);
       return;
     }
-    const title = sanitizeRemixerTitle(
+    const title = toEditableRemixerTitle(
       currentPage.title ?? currentPage["@title"] ?? "",
-      true,
       isBookRoot,
     );
     setPage({ ...currentPage, title, "@title": title });
@@ -213,11 +206,11 @@ const EditPanel: React.FC<EditPanelProps> = (props) => {
               placeholder="Loading title..."
               value={page?.title ?? page?.["@title"] ?? ""}
               onChange={(e) => {
-                const next = sanitizeRemixerTitle(
-                  e.target.value,
-                  false,
-                  isBookRoot,
-                );
+                // Hyphenate colons as they are typed, but never strip a
+                // numbering prefix mid-edit — that happens on load/save only.
+                const next = isBookRoot
+                  ? e.target.value
+                  : sanitizeRemixerPageTitle(e.target.value, false);
                 setPage((prev) =>
                   prev ? { ...prev, title: next, "@title": next } : prev,
                 );

--- a/client/src/components/remixer/RemixerDashboard.tsx
+++ b/client/src/components/remixer/RemixerDashboard.tsx
@@ -45,6 +45,7 @@ import {
   isBookLevelCatalogNode,
   isLibrary,
   isMatterBranchNode as isMatterBranchNodePure,
+  isRemixerBookRoot,
   isRestrictedLibraryShelfNode,
   isBackMatterNode,
   isDefaultMatterPage,
@@ -59,6 +60,7 @@ import {
   splitFormattedPathParts,
   splitStoredFormattedPath,
   syncRenamedItemFromAutonumberTitle,
+  toEditableRemixerTitle,
   withDerivedStatusFlags,
 } from "./services";
 import {
@@ -880,19 +882,19 @@ const RemixerDashboard: React.FC = () => {
     );
     if (!existingNode) return;
 
-    const isBookRoot = !existingNode.parentID || existingNode.parentID === "-1";
-    const normalizeEditTitle = (value: string) => {
-      if (isBookRoot) return value.trim();
-      let s = value;
-      const colonIndex = s.indexOf(":");
-      if (colonIndex !== -1) s = s.slice(colonIndex + 1);
-      return s.replace(/:/g, "").trim();
-    };
+    const isBookRoot = isRemixerBookRoot(existingNode, remixerData.liberCoverID);
 
-    const previousTitle = normalizeEditTitle(
+    // Both sides go through the same canonicalizer EditPanel seeds its field
+    // with, so a save with no edits compares equal instead of registering as
+    // a rename (which the job would replay as a real MindTouch move).
+    const previousTitle = toEditableRemixerTitle(
       existingNode.title || existingNode["@title"] || "",
+      isBookRoot,
     );
-    const nextTitle = normalizeEditTitle(page.title || page["@title"] || "");
+    const nextTitle = toEditableRemixerTitle(
+      page.title || page["@title"] || "",
+      isBookRoot,
+    );
     const titleChanged = previousTitle !== nextTitle;
     const prevOverride = existingNode.formattedPathOverride === true;
     const nextOverrideUriUiEnding = page.overrideUriUiEnding || existingNode.overrideUriUiEnding;

--- a/client/src/components/remixer/services.ts
+++ b/client/src/components/remixer/services.ts
@@ -145,6 +145,53 @@ export const stripDefaultTitlePrefixBeforeColon = (value: string): string => {
 };
 
 /**
+ * Colons are the namespace/numbering separator in MindTouch page paths, so they
+ * must never survive into an individual page title. Book (cover) titles are
+ * exempt and keep colons verbatim.
+ */
+export const sanitizeRemixerPageTitle = (
+  value: string,
+  trim: boolean = true,
+): string => {
+  const s = value.replace(/:/g, "-");
+  return trim ? s.trim() : s;
+};
+
+/**
+ * Canonical editable form of a stored title: the autonumber prefix is removed
+ * (numbering is re-applied at render time by `getRemixerDisplayTitle`) and any
+ * remaining colons are hyphenated.
+ *
+ * This is the single source of truth for title normalization. `EditPanel` uses
+ * it to seed the title field and `handleSaveEdit` uses it on both sides of its
+ * change comparison, so opening a page and saving without edits is a genuine
+ * no-op rather than a phantom rename. Idempotent: canonical input is returned
+ * unchanged.
+ */
+export const toEditableRemixerTitle = (
+  value: string,
+  isBookRoot: boolean,
+): string => {
+  if (isBookRoot) return value.trim();
+  return sanitizeRemixerPageTitle(
+    stripDefaultTitlePrefixBeforeColon(stripLeadingNumbering(value)),
+  );
+};
+
+/**
+ * The book root is the cover page. `parentID` is normally "-1" for it, but match
+ * on the project's cover id too so both call sites agree on one definition.
+ */
+export const isRemixerBookRoot = (
+  page: Pick<RemixerSubPage, "@id" | "parentID"> | undefined,
+  coverPageId: string | undefined,
+): boolean => {
+  if (!page) return false;
+  if (!page.parentID || page.parentID === "-1") return true;
+  return !!coverPageId && page["@id"] === coverPageId;
+};
+
+/**
  * Title used to detect duplicate siblings. The raw title is kept as-is (including any
  * literal "(n)" the user typed) so that a manually-typed "(1)" is never stripped away —
  * it's treated as part of that node's real identity, not an auto-generated suffix.


### PR DESCRIPTION
Converts colon to hyphen for chapters and subpages of the book on edit panel